### PR TITLE
Use https instead of git to clone repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Occasionally, filtering code will have to be updated when line numbers change.
 
 ```
 # clone the repositories:
-git clone git@github.com:michallepicki/elixir-lang-dialyzer-runs.git
+git clone https://github.com/michallepicki/elixir-lang-dialyzer-runs.git
 cd elixir-lang-dialyzer-runs
-git clone git@github.com:elixir-lang/elixir.git --depth=1
+git clone https://github.com/elixir-lang/elixir.git --depth=1
 
 # build elixir:
 cd elixir


### PR DESCRIPTION
"git" will no longer work in GitHub, as you will get:

> Cloning into 'elixir-lang-dialyzer-runs'...
> git@github.com: Permission denied (publickey).
> fatal: Could not read from remote repository.
>
> Please make sure you have the correct access rights
> and the repository exists.